### PR TITLE
refactor: centralize package and notification constants

### DIFF
--- a/app/src/main/java/io/github/amapnotifyfix/HookConstants.java
+++ b/app/src/main/java/io/github/amapnotifyfix/HookConstants.java
@@ -1,0 +1,26 @@
+package io.github.amapnotifyfix;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Common constants used by both legacy and modern entry points.
+ */
+public final class HookConstants {
+    private HookConstants() {}
+
+    /** Packages of Xiaomi's fitness apps that should be hooked. */
+    public static final Set<String> TARGET_PACKAGES = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(
+                    "com.xiaomi.wearable",
+                    "com.mi.health",
+                    "com.xiaomi.hm.health")));
+
+    /** Package name of Amap (Gaode Map). */
+    public static final String AMAP_PACKAGE = "com.autonavi.minimap";
+
+    /** Notification id used by Amap's persistent navigation notification. */
+    public static final int AMAP_NAV_ID = 0x4d4;
+}

--- a/app/src/main/java/io/github/amapnotifyfix/LegacyInit.java
+++ b/app/src/main/java/io/github/amapnotifyfix/LegacyInit.java
@@ -2,10 +2,16 @@ package io.github.amapnotifyfix;
 
 import android.service.notification.StatusBarNotification;
 
+import java.util.Set;
+
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
-import de.robv.android.xposed.callbacks.XC_LoadPackage;
 import de.robv.android.xposed.XposedHelpers;
+import de.robv.android.xposed.callbacks.XC_LoadPackage;
+
+import static io.github.amapnotifyfix.HookConstants.AMAP_NAV_ID;
+import static io.github.amapnotifyfix.HookConstants.AMAP_PACKAGE;
+import static io.github.amapnotifyfix.HookConstants.TARGET_PACKAGES;
 
 /**
  * Legacy Xposed entry (works in LSPosed too).
@@ -16,9 +22,8 @@ public class LegacyInit implements IXposedHookLoadPackage {
     @Override
     public void handleLoadPackage(final XC_LoadPackage.LoadPackageParam lpparam) throws Throwable {
         String pkg = lpparam.packageName;
-        if (!"com.xiaomi.wearable".equals(pkg)
-                && !"com.mi.health".equals(pkg)
-                && !"com.xiaomi.hm.health".equals(pkg)) {
+        Set<String> targets = TARGET_PACKAGES;
+        if (!targets.contains(pkg)) {
             return;
         }
         try {
@@ -32,8 +37,8 @@ public class LegacyInit implements IXposedHookLoadPackage {
                         protected void beforeHookedMethod(MethodHookParam param) {
                             StatusBarNotification sbn = (StatusBarNotification) param.args[0];
                             if (sbn != null
-                                    && "com.autonavi.minimap".equals(sbn.getPackageName())
-                                    && sbn.getId() == 0x4d4) {
+                                    && AMAP_PACKAGE.equals(sbn.getPackageName())
+                                    && sbn.getId() == AMAP_NAV_ID) {
                                 param.setResult(false);
                             }
                         }

--- a/app/src/main/java/io/github/amapnotifyfix/ModernEntry.java
+++ b/app/src/main/java/io/github/amapnotifyfix/ModernEntry.java
@@ -3,10 +3,15 @@ package io.github.amapnotifyfix;
 import android.service.notification.StatusBarNotification;
 
 import java.lang.reflect.Method;
+import java.util.Set;
 
 import io.github.libxposed.api.XposedInterface;
 import io.github.libxposed.api.XposedModule;
 import io.github.libxposed.api.XposedModuleInterface;
+
+import static io.github.amapnotifyfix.HookConstants.AMAP_NAV_ID;
+import static io.github.amapnotifyfix.HookConstants.AMAP_PACKAGE;
+import static io.github.amapnotifyfix.HookConstants.TARGET_PACKAGES;
 
 /**
  * Modern LSPosed (libxposed API 100) entry.
@@ -23,9 +28,8 @@ public class ModernEntry extends XposedModule {
     public void onPackageLoaded(XposedModuleInterface.PackageLoadedParam param) {
         String pkg = param.getPackageName();
         // 仅在小米运动健康相关包内工作
-        if (!"com.xiaomi.wearable".equals(pkg)
-                && !"com.mi.health".equals(pkg)
-                && !"com.xiaomi.hm.health".equals(pkg)) {
+        Set<String> targets = TARGET_PACKAGES;
+        if (!targets.contains(pkg)) {
             return;
         }
         try {
@@ -49,8 +53,8 @@ public class ModernEntry extends XposedModule {
                 if (args != null && args.length > 0 && args[0] instanceof StatusBarNotification) {
                     StatusBarNotification sbn = (StatusBarNotification) args[0];
                     // 仅针对高德导航这条常驻通知 (id = 0x4d4) 关闭过滤
-                    if ("com.autonavi.minimap".equals(sbn.getPackageName())
-                            && sbn.getId() == 0x4d4) {
+                    if (AMAP_PACKAGE.equals(sbn.getPackageName())
+                            && sbn.getId() == AMAP_NAV_ID) {
                         // 让 isMipmapNotification 直接返回 false，并跳过原方法
                         callback.returnAndSkip(false);
                     }


### PR DESCRIPTION
## Summary
- centralize Xiaomi fitness package names and Amap navigation notification metadata
- reuse constants in both legacy and modern Xposed entries

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac1fbbb5c48323ab8498d84df7a1ee