### PR TITLE
Fix LSPosed module metadata for default scope and description

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,12 +4,13 @@
 
     <application
         android:label="Mi Fitness Amap Nav Fix"
+        android:description="@string/module_description"
         android:allowBackup="false"
         android:supportsRtl="true">
         <meta-data android:name="xposedscope" android:resource="@array/xposed_scope" />
         <!-- Legacy Xposed module metadata (recognized by LSPosed as well) -->
         <meta-data android:name="xposedmodule" android:value="true" />
-        <meta-data android:name="xposeddescription" android:value="Fix Mi Fitness blocking Amap navigation notifications" />
+        <meta-data android:name="xposeddescription" android:resource="@string/module_description" />
         <meta-data android:name="xposedminversion" android:value="93" />
     </application>
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,5 +1,5 @@
-<resources>
-    <string-array name="xposed_scope">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@array/xposed_scope">
+    <string-array name="xposed_scope" translatable="false">
         <item>com.mi.health</item>
         <item>com.xiaomi.wearable</item>
         <item>com.xiaomi.hm.health</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="module_description" translatable="false">Fix Mi Fitness blocking Amap navigation notifications</string>
+</resources>


### PR DESCRIPTION
## Summary
- ensure xposed scope array is kept during resource shrinking
- provide module description resource and reference it from manifest

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ac5bbd4de48323a43c149cf8437489